### PR TITLE
Version Bump

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>thycotic-secret-server</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <packaging>hpi</packaging>
     <properties>
         <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->


### PR DESCRIPTION
Looks like I forgot to bump the version in the POM file which might be causing the CD issue. Once merged to main we can retag with v1.0.2 and trigger the CD.
